### PR TITLE
Upgrade to latest flutter_bloc version #84

### DIFF
--- a/lib/blocs/locale/locale_bloc.dart
+++ b/lib/blocs/locale/locale_bloc.dart
@@ -10,17 +10,13 @@ part 'locale_state.dart';
 
 class LocaleBloc extends Bloc<LocaleEvent, LocaleState> {
   final SettingsProvider settings;
-  LocaleBloc(this.settings) : super(const LocaleState(null));
-
-  @override
-  Stream<LocaleState> mapEventToState(
-    LocaleEvent event,
-  ) async* {
-    if (event is LoadLocaleEvent) {
-      yield LocaleState(settings.getLocale());
-    } else if (event is ChangeLocaleEvent) {
+  LocaleBloc(this.settings) : super(const LocaleState(null)) {
+    on<LoadLocaleEvent>((event, emit) {
+      emit(LocaleState(settings.getLocale()));
+    });
+    on<ChangeLocaleEvent>((event, emit) {
       settings.setLocale(event.locale);
-      yield LocaleState(event.locale);
-    }
+      emit(LocaleState(event.locale));
+    });
   }
 }

--- a/lib/blocs/notifications/notifications_bloc.dart
+++ b/lib/blocs/notifications/notifications_bloc.dart
@@ -9,22 +9,19 @@ part 'notifications_state.dart';
 
 class NotificationsBloc extends Bloc<NotificationsEvent, NotificationsState> {
   final NotificationsProvider notifications;
-  NotificationsBloc(this.notifications) : super(const NotificationsState());
-
-  @override
-  Stream<NotificationsState> mapEventToState(
-    NotificationsEvent event,
-  ) async* {
-    if (event is RequestNotificationPermissions) {
+  NotificationsBloc(this.notifications) : super(const NotificationsState()) {
+    on<RequestNotificationPermissions>((event, emit) async {
       await notifications.requestPermissions();
-      yield const NotificationsState();
-    } else if (event is ShowNotification) {
+      emit(const NotificationsState());
+    });
+    on<ShowNotification>((event, emit) async {
       await notifications.displayRunningTimersNotification(
           event.title, event.body);
-      yield const NotificationsState();
-    } else if (event is RemoveNotifications) {
+      emit(const NotificationsState());
+    });
+    on<RemoveNotifications>((event, emit) async {
       await notifications.removeAllNotifications();
-      yield const NotificationsState();
-    }
+      emit(const NotificationsState());
+    });
   }
 }

--- a/lib/blocs/projects/projects_bloc.dart
+++ b/lib/blocs/projects/projects_bloc.dart
@@ -20,41 +20,41 @@ import './bloc.dart';
 
 class ProjectsBloc extends Bloc<ProjectsEvent, ProjectsState> {
   final DataProvider data;
-  ProjectsBloc(this.data) : super(ProjectsState.initial());
-
-  @override
-  Stream<ProjectsState> mapEventToState(
-    ProjectsEvent event,
-  ) async* {
-    if (event is LoadProjects) {
+  ProjectsBloc(this.data) : super(ProjectsState.initial()) {
+    on<LoadProjects>((event, emit) async {
       List<Project> projects = await data.listProjects();
-      yield ProjectsState(projects);
-    } else if (event is CreateProject) {
+      emit(ProjectsState(projects));
+    });
+
+    on<CreateProject>((event, emit) async {
       Project newProject =
           await data.createProject(name: event.name, colour: event.colour);
       List<Project> projects =
           state.projects.map((project) => Project.clone(project)).toList();
       projects.add(newProject);
       projects.sort((a, b) => a.name.compareTo(b.name));
-      yield ProjectsState(projects);
-    } else if (event is EditProject) {
+      emit(ProjectsState(projects));
+    });
+
+    on<EditProject>((event, emit) async {
       await data.editProject(event.project);
       List<Project> projects = state.projects.map((project) {
         if (project.id == event.project.id) return Project.clone(event.project);
         return Project.clone(project);
       }).toList();
       projects.sort((a, b) => a.name.compareTo(b.name));
-      yield ProjectsState(projects);
-    } else if (event is DeleteProject) {
+      emit(ProjectsState(projects));
+    });
+
+    on<DeleteProject>((event, emit) async {
       await data.deleteProject(event.project);
       List<Project> projects = state.projects
           .where((p) => p.id != event.project.id)
           .map((p) => Project.clone(p))
           .toList();
-      yield ProjectsState(projects);
-    }
+      emit(ProjectsState(projects));
+    });
   }
-
   Project? getProjectByID(int? id) {
     if (id == null) return null;
     for (Project p in state.projects) {

--- a/lib/blocs/theme/theme_bloc.dart
+++ b/lib/blocs/theme/theme_bloc.dart
@@ -12,17 +12,14 @@ part 'theme_state.dart';
 
 class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
   final SettingsProvider settings;
-  ThemeBloc(this.settings) : super(const ThemeState(ThemeType.auto));
+  ThemeBloc(this.settings) : super(const ThemeState(ThemeType.auto)) {
+    on<LoadThemeEvent>((event, emit) {
+      emit(ThemeState(settings.getTheme()));
+    });
 
-  @override
-  Stream<ThemeState> mapEventToState(
-    ThemeEvent event,
-  ) async* {
-    if (event is LoadThemeEvent) {
-      yield ThemeState(settings.getTheme());
-    } else if (event is ChangeThemeEvent) {
+    on<ChangeThemeEvent>((event, emit) {
       settings.setTheme(event.theme);
-      yield ThemeState(event.theme);
-    }
+      emit(ThemeState(event.theme));
+    });
   }
 }

--- a/lib/blocs/timers/timers_bloc.dart
+++ b/lib/blocs/timers/timers_bloc.dart
@@ -22,26 +22,27 @@ import './bloc.dart';
 class TimersBloc extends Bloc<TimersEvent, TimersState> {
   final DataProvider data;
   final SettingsProvider settings;
-  TimersBloc(this.data, this.settings) : super(TimersState.initial());
-
-  @override
-  Stream<TimersState> mapEventToState(
-    TimersEvent event,
-  ) async* {
-    if (event is LoadTimers) {
+  TimersBloc(this.data, this.settings) : super(TimersState.initial()) {
+    on<LoadTimers>((event, emit) async {
       List<TimerEntry> timers = await data.listTimers();
-      yield TimersState(timers, DateTime.now());
-    } else if (event is CreateTimer) {
+      emit(TimersState(timers, DateTime.now()));
+    });
+
+    on<CreateTimer>((event, emit) async {
       TimerEntry timer = await data.createTimer(
           description: event.description, projectID: event.project?.id);
       List<TimerEntry> timers =
           state.timers.map((t) => TimerEntry.clone(t)).toList();
       timers.add(timer);
       timers.sort((a, b) => a.startTime.compareTo(b.startTime));
-      yield TimersState(timers, DateTime.now());
-    } else if (event is UpdateNow) {
-      yield TimersState(state.timers, DateTime.now());
-    } else if (event is StopTimer) {
+      emit(TimersState(timers, DateTime.now()));
+    });
+
+    on<UpdateNow>((event, emit) {
+      emit(TimersState(state.timers, DateTime.now()));
+    });
+
+    on<StopTimer>((event, emit) async {
       TimerEntry timer = TimerEntry.clone(event.timer, endTime: DateTime.now());
       await data.editTimer(timer);
       List<TimerEntry> timers = state.timers.map((t) {
@@ -49,23 +50,29 @@ class TimersBloc extends Bloc<TimersEvent, TimersState> {
         return TimerEntry.clone(t);
       }).toList();
       timers.sort((a, b) => a.startTime.compareTo(b.startTime));
-      yield TimersState(timers, DateTime.now());
-    } else if (event is EditTimer) {
+      emit(TimersState(timers, DateTime.now()));
+    });
+
+    on<EditTimer>((event, emit) async {
       await data.editTimer(event.timer);
       List<TimerEntry> timers = state.timers.map((t) {
         if (t.id == event.timer.id) return TimerEntry.clone(event.timer);
         return TimerEntry.clone(t);
       }).toList();
       timers.sort((a, b) => a.startTime.compareTo(b.startTime));
-      yield TimersState(timers, DateTime.now());
-    } else if (event is DeleteTimer) {
+      emit(TimersState(timers, DateTime.now()));
+    });
+
+    on<DeleteTimer>((event, emit) async {
       await data.deleteTimer(event.timer);
       List<TimerEntry> timers = state.timers
           .where((t) => t.id != event.timer.id)
           .map((t) => TimerEntry.clone(t))
           .toList();
-      yield TimersState(timers, DateTime.now());
-    } else if (event is StopAllTimers) {
+      emit(TimersState(timers, DateTime.now()));
+    });
+
+    on<StopAllTimers>((event, emit) async {
       List<Future<TimerEntry>> timerEdits = state.timers.map((t) async {
         if (t.endTime == null) {
           TimerEntry timer = TimerEntry.clone(t, endTime: DateTime.now());
@@ -77,7 +84,7 @@ class TimersBloc extends Bloc<TimersEvent, TimersState> {
 
       List<TimerEntry> timers = await Future.wait(timerEdits);
       timers.sort((a, b) => a.startTime.compareTo(b.startTime));
-      yield TimersState(timers, DateTime.now());
-    }
+      emit(TimersState(timers, DateTime.now()));
+    });
   }
 }

--- a/lib/screens/dashboard/bloc/dashboard_bloc.dart
+++ b/lib/screens/dashboard/bloc/dashboard_bloc.dart
@@ -16,39 +16,42 @@ class DashboardBloc extends Bloc<DashboardEvent, DashboardState> {
 
   DashboardBloc(this.projectsBloc, this.settingsBloc)
       : super(DashboardState("", projectsBloc.getProjectByID(-1), false,
-            settingsBloc.getFilterStartDate(), null, const <int>[], null));
-
-  @override
-  Stream<DashboardState> mapEventToState(
-    DashboardEvent event,
-  ) async* {
-    if (event is DescriptionChangedEvent) {
-      yield DashboardState(
+            settingsBloc.getFilterStartDate(), null, const <int>[], null)) {
+    on<DescriptionChangedEvent>((event, emit) {
+      emit(DashboardState(
           event.description!,
           state.newProject,
           false,
           state.filterStart,
           state.filterEnd,
           state.hiddenProjects,
-          state.searchString);
-    } else if (event is ProjectChangedEvent) {
-      yield DashboardState(
+          state.searchString));
+    });
+
+    on<ProjectChangedEvent>((event, emit) {
+      emit(DashboardState(
           state.newDescription,
           event.project,
           false,
           state.filterStart,
           state.filterEnd,
           state.hiddenProjects,
-          state.searchString);
-    } else if (event is TimerWasStartedEvent) {
+          state.searchString));
+    });
+
+    on<TimerWasStartedEvent>((event, emit) {
       Project? newProject = projectsBloc.getProjectByID(-1);
-      yield DashboardState("", newProject, true, state.filterStart,
-          state.filterEnd, state.hiddenProjects, state.searchString);
-    } else if (event is ResetEvent) {
+      emit(DashboardState("", newProject, true, state.filterStart,
+          state.filterEnd, state.hiddenProjects, state.searchString));
+    });
+
+    on<ResetEvent>((event, emit) {
       Project? newProject = projectsBloc.getProjectByID(-1);
-      yield DashboardState("", newProject, false, state.filterStart,
-          state.filterEnd, state.hiddenProjects, state.searchString);
-    } else if (event is FilterStartChangedEvent) {
+      emit(DashboardState("", newProject, false, state.filterStart,
+          state.filterEnd, state.hiddenProjects, state.searchString));
+    });
+
+    on<FilterStartChangedEvent>((event, emit) {
       final filterStart = event.filterStart;
       DateTime? end = state.filterEnd;
       if (end != null && filterStart != null && filterStart.isAfter(end)) {
@@ -56,35 +59,41 @@ class DashboardBloc extends Bloc<DashboardEvent, DashboardState> {
             hours: 23, minutes: 59, seconds: 59, milliseconds: 999));
       }
 
-      yield DashboardState(state.newDescription, state.newProject, false,
-          event.filterStart, end, state.hiddenProjects, state.searchString);
-    } else if (event is FilterEndChangedEvent) {
-      yield DashboardState(
+      emit(DashboardState(state.newDescription, state.newProject, false,
+          event.filterStart, end, state.hiddenProjects, state.searchString));
+    });
+
+    on<FilterEndChangedEvent>((event, emit) {
+      emit(DashboardState(
           state.newDescription,
           state.newProject,
           false,
           state.filterStart,
           event.filterEnd,
           state.hiddenProjects,
-          state.searchString);
-    } else if (event is FilterProjectsChangedEvent) {
-      yield DashboardState(
+          state.searchString));
+    });
+
+    on<FilterProjectsChangedEvent>((event, emit) {
+      emit(DashboardState(
           state.newDescription,
           state.newProject,
           false,
           state.filterStart,
           state.filterEnd,
           event.projects,
-          state.searchString);
-    } else if (event is SearchChangedEvent) {
-      yield DashboardState(
+          state.searchString));
+    });
+
+    on<SearchChangedEvent>((event, emit) {
+      emit(DashboardState(
           state.newDescription,
           state.newProject,
           false,
           state.filterStart,
           state.filterEnd,
           state.hiddenProjects,
-          event.search);
-    }
+          event.search));
+    });
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   sqflite_common_ffi:
-  flutter_bloc: ^7.2.1
-  bloc: ^7.2.1
+  flutter_bloc: ^8.1.1
+  bloc: ^8.1.0
   equatable: ^2.0.5
   path: ^1.8.2
   collection: ^1.16.0


### PR DESCRIPTION
The [flutter_bloc](https://pub.dev/packages/flutter_bloc) library was upgraded from 7.2.1 to 8.1.1 and [bloc](https://pub.dev/packages/bloc) library was upgraded from 7.2.1 to 8.1.0.

In bloc v7.2.0, `mapEventToState` was deprecated in favor of `on<Event>`. `mapEventToState` was removed in bloc v8.0.0. So, the `mapEventToState` have been changed to `on<Event>`

Please review it.