### PR TITLE
Fix #105

### DIFF
--- a/lib/screens/dashboard/components/ProjectSelectField.dart
+++ b/lib/screens/dashboard/components/ProjectSelectField.dart
@@ -60,9 +60,9 @@ class _ProjectSelectFieldState extends State<ProjectSelectField> {
                 ? "${L10N.of(context).tr.project} ($projectName)"
                 : L10N.of(context).tr.project,
             onPressed: () async {
-              Project? chosenProject = await showDialog<Project>(
+              _ProjectChoice? projectChoice = await showDialog<_ProjectChoice>(
                   context: context,
-                  barrierDismissible: false,
+                  barrierDismissible: true,
                   builder: (BuildContext context) {
                     return SimpleDialog(
                       title: Text(L10N.of(context).tr.projects),
@@ -73,7 +73,7 @@ class _ProjectSelectFieldState extends State<ProjectSelectField> {
                               projectsState.projects.where((p) => !p.archived))
                           .map((Project? p) => TextButton(
                               onPressed: () {
-                                Navigator.of(context).pop(p);
+                                Navigator.of(context).pop(_ProjectChoice(p));
                               },
                               child: Row(
                                 children: <Widget>[
@@ -98,11 +98,23 @@ class _ProjectSelectFieldState extends State<ProjectSelectField> {
                           .toList(),
                     );
                   });
-              bloc.add(ProjectChangedEvent(chosenProject));
+
+              if (projectChoice != null) {
+                bloc.add(ProjectChangedEvent(projectChoice.chosenProject));
+              }
             },
           );
         },
       );
     });
   }
+}
+
+/// A class that stores the project that has been chosen by the user.
+///
+/// [chosenProject] may be `null` in case the user has chosen “(no project)”.
+class _ProjectChoice {
+  final Project? chosenProject;
+
+  _ProjectChoice(this.chosenProject);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -430,6 +430,11 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   intl:
     dependency: "direct main"
     description:


### PR DESCRIPTION
This PR fixes #105.

The issue was caused by the fact that the “(no project)” choice of the user was represented by the `chosenProject` variable in the `ProjectSelectField.dart` file being `null`. Since dismissing the dialog also caused `null` to be returned from the `showDialog` function, the dialog's `barrierDismissible` property was set to `false` to prevent bugs.

This PR adds a new private class called `_ProjectChoice` which is instead returned from the `showDialog` function. If it is `null`, then the dialog has been dismissed and the `Bloc` is not notified of any `ProjectChangedEvent`. Otherwise, the `Bloc` is notified of the `_ProjectChoice`'s `chosenProject` property, which may be `null` in case the user selected the “(no project)” choice in the dialog.