### PR TITLE
Fixed the storage permission error when importing in Android by adding the 'read and write to external storage' permissions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ lib/generated_plugin_registrant.dart
 
 # Exceptions to above rules.
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+
+# APK keystores
+timecop_keystore.jks
+key.properties

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <application
         android:name="${applicationName}"
         android:label="Time Cop"


### PR DESCRIPTION
I've added the "WRITE_EXTERNAL_STORAGE" permission but am unsure of how to implement exporting the database to the external storage instead of "Sharing" it like is done now. 

I may open an issue requesting there to be a third option in the list when you click the database icon: ['Import Database', 'Export Database', 'Share Database'].