### PR TITLE
Line Chart bottom text cut off issue fixed #112

### DIFF
--- a/lib/screens/reports/components/WeeklyTotals.dart
+++ b/lib/screens/reports/components/WeeklyTotals.dart
@@ -162,14 +162,18 @@ class _WeeklyTotalsState extends State<WeeklyTotals> {
                       )),
                       bottomTitles: AxisTitles(
                         sideTitles: SideTitles(
+                            reservedSize: 35,
                             showTitles: true,
                             getTitlesWidget: (double dweek, _) {
                               int week = dweek.toInt();
                               DateTime date =
                                   firstDate!.add(Duration(days: week * 7));
-                              return Text(
-                                dateFormat.format(date).replaceAll(' ', '\n'),
-                                style: theme.textTheme.bodySmall,
+                              return Padding(
+                                padding: const EdgeInsets.all(2.0),
+                                child: Text(
+                                  dateFormat.format(date).replaceAll(' ', '\n'),
+                                  style: theme.textTheme.bodySmall,
+                                ),
                               );
                             }),
                       )),


### PR DESCRIPTION
Line Chart bottom text cut off issue fixed by reserving space for the text and added padding to maintain some space between X and Y Axis Number.