### PR TITLE
fix: truncate default start date filter to start of day

### DIFF
--- a/lib/blocs/settings/settings_bloc.dart
+++ b/lib/blocs/settings/settings_bloc.dart
@@ -222,12 +222,12 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     });
   }
   DateTime? getFilterStartDate() {
+    // Truncate date to start of day so every entries are pulled when filtering
+    DateTime now = DateTime.now().copyWith(hour: 0, minute: 0, second: 0)
     if (state.defaultFilterStartDateToMonday) {
-      var dayOfWeek = 1; // Monday=1, Tuesday=2...
-      DateTime date = DateTime.now();
-      return date.subtract(Duration(days: date.weekday - dayOfWeek));
+      return now.subtract(Duration(days: date.weekday - DateTime.monday));
     } else if (state.defaultFilterDays > 0) {
-      return DateTime.now().subtract(Duration(days: state.defaultFilterDays));
+      return now.subtract(Duration(days: state.defaultFilterDays));
     } else {
       return null;
     }


### PR DESCRIPTION
Since `getFilterStartDate` uses `DateTime.now()` if an entry was created Monday morning at 0800, and I come back to check Timecop, same Monday, at 1200 with the "auto start date Monday filter" activated in the settings, the 0800 entry won't show up.
Using `DateTime.copyWith` allows us to truncate the current date to the start of the day.

This issue still arises even with the "auto start date Monday filter" turn off, since all entries prior (in terms of _hour:minute:second_) to the current time won't show up.